### PR TITLE
feat: handle save errors

### DIFF
--- a/src/__test__/integration/CreateBoulder/saveBoulder.test.tsx
+++ b/src/__test__/integration/CreateBoulder/saveBoulder.test.tsx
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-react";
 import { userEvent } from "vitest/browser";
 import "@/app/styles/globals.css";
 import CreateBoulder from "@/app/(create-boulder)/components/CreateBoulder/CreateBoulder";
+import { saveBoulderErrors } from "@/features/SaveBoulder/constants/errorsMessages";
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
@@ -19,7 +20,11 @@ beforeAll(() => {
 test("Save boulder: User can open save modal and save a boulder", async () => {
   window.localStorage.clear();
 
-  const { getByRole, getByLabelText, getByTestId } = await render(<CreateBoulder />);
+  const { getByRole, getByLabelText, getByTestId, getByTitle } = await render(<CreateBoulder />);
+
+  await userEvent.click(getByTestId("test-hold"));
+  await userEvent.click(getByTitle("top"));
+  await userEvent.click(getByTestId("test-top"));
 
   const trigger = getByRole("button", { name: "Save Boulder" });
 
@@ -40,4 +45,41 @@ test("Save boulder: User can open save modal and save a boulder", async () => {
   const parsedData = JSON.parse(storedData!);
   expect(parsedData).toHaveLength(1);
   expect(parsedData[0].name).toBe("My Awesome Boulder");
+});
+
+test("Save boulder: User gets an error message if name already exists", async () => {
+  const { getByRole, getByLabelText, getByTestId, getByText } = await render(<CreateBoulder />);
+
+  const trigger = getByRole("button", { name: "Save Boulder" });
+
+  await userEvent.click(trigger);
+
+  const nameInput = getByLabelText("Name");
+  await userEvent.clear(nameInput);
+  await userEvent.fill(nameInput, "My Awesome Boulder");
+  const submitButton = await getByTestId("test-save-boulder");
+
+  await userEvent.click(submitButton);
+
+  await expect.element(getByText(saveBoulderErrors.nameExists)).toBeInTheDocument();
+});
+
+test("Save boulder: User gets an error message if no start or top holds are set", async () => {
+  const { getByRole, getByLabelText, getByTestId, getByText, getByTitle } = await render(<CreateBoulder />);
+
+  const clearButton = getByTitle("clear boulder");
+  await userEvent.click(clearButton);
+
+  const trigger = getByRole("button", { name: "Save Boulder" });
+  await userEvent.click(trigger);
+
+  const nameInput = getByLabelText("Name");
+  await userEvent.clear(nameInput);
+  await userEvent.fill(nameInput, "Test");
+  const submitButton = await getByTestId("test-save-boulder");
+
+  await userEvent.click(submitButton);
+
+  await expect.element(getByText(saveBoulderErrors.noStartHold)).toBeInTheDocument();
+  await expect.element(getByText(saveBoulderErrors.noTopHold)).toBeInTheDocument();
 });

--- a/src/app/(create-boulder)/components/CreateBoulder/CreateBoulder.tsx
+++ b/src/app/(create-boulder)/components/CreateBoulder/CreateBoulder.tsx
@@ -15,20 +15,21 @@ import BoardFooter from "@/components/common/BoardFooter/BoardFooter";
 import ClearBoulder from "@/features/ClearBoulder/ClearBoulder";
 import GoToBoulderListButton from "@/components/common/GoToBoulderListButton/GoToBoulderListButton";
 import BoardHeaderBar from "@/components/common/BoardHeaderNav/BoardHeaderBar";
+import useSaveBoulder from "@/features/SaveBoulder/hooks/useSaveBoulder/useSaveBoulder";
 
 const creationBoardStateSelector = (state: NewBoulderStore) => ({
   boulder: state.boulder,
   setActiveType: state.setActiveType,
   activeType: state.activeType,
-  saveToLocalStorage: state.saveToLocalStorage,
 });
 
 export default function CreateBoulder() {
   const { onBoardClick } = UseCreateBoulderActions();
   const memoizedSelector = useShallow(creationBoardStateSelector);
   const router = useRouter();
+  const { saveToLocalStorage } = useSaveBoulder();
 
-  const { boulder, setActiveType, activeType, saveToLocalStorage } =
+  const { boulder, setActiveType, activeType } =
     useNewBoulderStore(memoizedSelector);
 
   const saveFn = (name: string, grade: string) => {

--- a/src/app/(create-boulder)/store/NewBoulderStore.ts
+++ b/src/app/(create-boulder)/store/NewBoulderStore.ts
@@ -4,7 +4,6 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { Boulder, HoldId, HoldTypes } from "@/features/Board/types";
 import { emptyBoulder } from "@/features/Board/constants/initialisers";
-import { BoulderListItemDto } from "@/domain/dtos/BoulderListItem.dto";
 
 const initialState = {
   boulder: { ...emptyBoulder },
@@ -29,45 +28,10 @@ const useNewBoulderStore = create<
           );
         }),
       setActiveType: (type) => set({ activeType: type }),
-      clearBoulder: () => set((state)=> {
+      clearBoulder: () => set((state) => {
         state.boulder = initialState.boulder as unknown as Boulder;
         state.activeType = HoldTypes.START;
       }),
-      
-      saveToLocalStorage: (boulderName: string, grade: string) => {
-        let success;
-
-         set((state) => {
-          // TO DO - handle type safety
-          // TO DO - handle name conflicts
-          // TO DO - extract key boulderList
-          const boulderWithGradeAndName = {
-            boulder: state.boulder,
-            name: boulderName,
-            grade,
-            id: Date.now().toString(),
-          };
-
-          const listString = localStorage.getItem("boulderList");
-          const list: BoulderListItemDto[] = listString
-            ? JSON.parse(listString)
-            : [];
-
-          list.push(boulderWithGradeAndName);
-
-          try {
-            localStorage.setItem("boulderList", JSON.stringify(list));
-            success = true;
-          } catch (error) {
-            success = false;
-          }
-
-          state.boulder = initialState.boulder as unknown as Boulder;
-          state.activeType = HoldTypes.START;
-        });
-
-        return success ? { success: true } : { success: false, error: "Failed to save boulder to localStorage" };
-      },
     }))
   )
 );

--- a/src/components/common/ErrorBlock/ErrorBlock.tsx
+++ b/src/components/common/ErrorBlock/ErrorBlock.tsx
@@ -1,0 +1,16 @@
+import { ErrorBlockProps } from "./ErrorsBlock.types";
+
+export default function ErrorBlock({ errors }: ErrorBlockProps) {
+    return (
+        <div className="border border-red-500 p-2 bg-red-200  text-red-500 rounded" role="alert">
+            <p className="sr-only">
+                Error:
+            </p>
+            <ul className="list-disc px-4">
+                {errors.map((error, index) => (
+                    <li key={index}>{error}</li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/common/ErrorBlock/ErrorsBlock.types.ts
+++ b/src/components/common/ErrorBlock/ErrorsBlock.types.ts
@@ -1,0 +1,3 @@
+export type ErrorBlockProps = {
+    errors: string[]
+}

--- a/src/components/icons/createBoulder.tsx
+++ b/src/components/icons/createBoulder.tsx
@@ -4,7 +4,7 @@ const CreateBoulderIcon = ({ className }: { className?: string }) => {
   return (
     <svg className={className} xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" viewBox="0 0 32 32" enable-background="new 0 0 32 32">
       <polygon points="22,16.8 22,26 6,26 6,10 15.2,10 17.2,8 4,8 4,28 24,28 24,14.8 " />
-      <path fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" d="M16.5,18.3L13,19l0.7-3.5l9.9-9.9  c0.8-0.8,2-0.8,2.8,0l0,0c0.8,0.8,0.8,2,0,2.8L16.5,18.3z" />
+      <path fill="none" stroke="#000000" stroke-width="2" d="M16.5,18.3L13,19l0.7-3.5l9.9-9.9  c0.8-0.8,2-0.8,2.8,0l0,0c0.8,0.8,0.8,2,0,2.8L16.5,18.3z" />
     </svg>);
 };
 

--- a/src/domain/contants/boulderGrades.ts
+++ b/src/domain/contants/boulderGrades.ts
@@ -2,7 +2,6 @@ const boulderGradesArray = [
   "3",
   "4",
   "5",
-  "6",
   "6A",
   "6A+",
   "6B",

--- a/src/features/ClearBoulder/ClearBoulder.tsx
+++ b/src/features/ClearBoulder/ClearBoulder.tsx
@@ -7,7 +7,7 @@ export default function ClearBoulder() {
 
     return (
         <div className="flex flex-col items-center">
-            <button className="p-2" onClick={clearBoulder}>
+            <button className="p-2" onClick={clearBoulder} title="clear boulder">
                 <ClearIcon className="h-5 w-5 [&_path]:stroke-white" />
             </button>
             <span className="text-white text-xs">Clear</span>

--- a/src/features/SaveBoulder/SaveBoulder.tsx
+++ b/src/features/SaveBoulder/SaveBoulder.tsx
@@ -18,10 +18,11 @@ const SaveBoulder = ({ saveFn }: SaveBoulderProps) => {
     const formData = new FormData(e.currentTarget);
     const boulderName = formData.get("boulderName") as string;
     const grade = formData.get("boulderGrade") as string;
+    const saveState = saveFn(boulderName, grade);
 
-    const { success } = saveFn(boulderName, grade);
+    if (saveState.success) toggleModal();
 
-    if (success) toggleModal();
+    return saveState;
   };
 
   return (

--- a/src/features/SaveBoulder/SaveBoulder.types.ts
+++ b/src/features/SaveBoulder/SaveBoulder.types.ts
@@ -1,3 +1,5 @@
+import { submitState } from "@/hooks/useFormError/useFormError.types";
+
 export interface SaveBoulderProps {
-  saveFn: (name: string, grade: string) => {success: boolean; error?: string};
+  saveFn: (name: string, grade: string) => submitState;
 }

--- a/src/features/SaveBoulder/components/SaveBoulderForm/SaveBoulderForm.tsx
+++ b/src/features/SaveBoulder/components/SaveBoulderForm/SaveBoulderForm.tsx
@@ -3,12 +3,16 @@ import React from "react";
 import { SaveBoulderFormProps } from "./SaveBoulderForm.types";
 import { boulderGrades } from "@/domain/contants/boulderGrades";
 import Select from "@/components/ui/Select";
+import useFormError from "@/hooks/useFormError/useFormError";
+import ErrorBlock from "@/components/common/ErrorBlock/ErrorBlock";
 
 const SaveBoulderForm = ({ onSubmit }: SaveBoulderFormProps) => {
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const submitFn = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    onSubmit(e);
+    return onSubmit(e);
   };
+
+  const { error, onSubmit: handleSubmit } = useFormError({ submitFn });
 
   return (
     <form
@@ -23,6 +27,7 @@ const SaveBoulderForm = ({ onSubmit }: SaveBoulderFormProps) => {
           name="boulderName"
           placeholder="Boulder name"
           defaultValue="My First Boulder"
+          aria-invalid={error ? true : undefined}
           required
         />
       </div>
@@ -43,6 +48,9 @@ const SaveBoulderForm = ({ onSubmit }: SaveBoulderFormProps) => {
           ))}
         </Select>
       </div>
+
+      {error?.length && <ErrorBlock errors={error} />}
+
       <button data-testid="test-save-boulder" className="bg-purple-400 p-2 rounded" type="submit">
         Save Boulder
       </button>

--- a/src/features/SaveBoulder/components/SaveBoulderForm/SaveBoulderForm.types.ts
+++ b/src/features/SaveBoulder/components/SaveBoulderForm/SaveBoulderForm.types.ts
@@ -1,5 +1,6 @@
 import React from "react";
+import { submitState } from "@/hooks/useFormError/useFormError.types";
 
 export interface SaveBoulderFormProps {
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => submitState;
 }

--- a/src/features/SaveBoulder/constants/errorsMessages.ts
+++ b/src/features/SaveBoulder/constants/errorsMessages.ts
@@ -1,0 +1,5 @@
+export const saveBoulderErrors = {
+    nameExists: "Boulder with this name already exists",
+    noStartHold: "Boulder must have a start hold",
+    noTopHold: "Boulder must have a top hold",
+}

--- a/src/features/SaveBoulder/hooks/useSaveBoulder/useSaveBoulder.tsx
+++ b/src/features/SaveBoulder/hooks/useSaveBoulder/useSaveBoulder.tsx
@@ -1,0 +1,49 @@
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { BoulderListItemDto } from "@/domain/dtos/BoulderListItem.dto";
+import useNewBoulderStore from "@/app/(create-boulder)/store/NewBoulderStore";
+import { NewBoulderStore } from "@/app/(create-boulder)/store/types";
+import { useShallow } from "zustand/shallow";
+import { saveBoulderErrors } from "../../constants/errorsMessages";
+
+const boulderStoreSelector = (state: NewBoulderStore) => ({
+    boulder: state.boulder,
+});
+
+export default function useSaveBoulder() {
+    const memoizedSelector = useShallow(boulderStoreSelector);
+    const [boulderList, setBoulderList] = useLocalStorage<BoulderListItemDto[]>(
+        "boulderList",
+        []
+    );
+
+    const { boulder } = useNewBoulderStore(memoizedSelector);
+
+
+    function saveToLocalStorage(boulderName: string, grade: string) {
+        const boulderWithGradeAndName = {
+            boulder: boulder,
+            name: boulderName,
+            grade,
+            id: Date.now().toString(),
+        };
+
+        const nameAlreadyExists = boulderList.some(b => b.name === boulderName);
+        const errors: string[] = [];
+
+        if (nameAlreadyExists) errors.push(saveBoulderErrors.nameExists);
+        if (!boulder.start.length) errors.push(saveBoulderErrors.noStartHold);
+        if (!boulder.top.length) errors.push(saveBoulderErrors.noTopHold);
+
+        if (errors.length) return { success: false, errors };
+
+        try {
+            setBoulderList([...boulderList, boulderWithGradeAndName])
+            return { success: true };
+        } catch (error) {
+            return { success: false, errors: ["Failed to save boulder to localStorage"] };
+        }
+    }
+
+    return { saveToLocalStorage }
+
+}

--- a/src/hooks/useFormError/useFormError.ts
+++ b/src/hooks/useFormError/useFormError.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+import { useFormErrorArgs } from "./useFormError.types";
+
+export default function useFormError({ submitFn }: useFormErrorArgs) {
+    const [error, setError] = useState<string[] | null>(null);
+
+    const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        const result = submitFn(e);
+        if (result.errors) setError(result.errors);
+    };
+
+    const clearError = () => setError(null);
+
+    return { error, onSubmit, clearError };
+}

--- a/src/hooks/useFormError/useFormError.types.ts
+++ b/src/hooks/useFormError/useFormError.types.ts
@@ -1,0 +1,5 @@
+export type useFormErrorArgs = {
+    submitFn: (e: React.FormEvent<HTMLFormElement>) => submitState
+}
+
+export type submitState = { success: boolean; errors?: string[] }


### PR DESCRIPTION
- Eliminates save boulder action from newBoulderStore
- Create useSaveBoudler hook where the new boulder is saved to local storage
- Adds checks for three error types on this hook: existing name / no hand holds / no top holds
- Includes new test for error scenarios